### PR TITLE
[ONEM-5064] fixed "No bb files matched BBFILE_PATTERN_xxx" warnings

### DIFF
--- a/lib/bb/cooker.py
+++ b/lib/bb/cooker.py
@@ -1713,7 +1713,7 @@ class CookerCollectFiles(object):
                 if matched != None:
                     if not regex in matched:
                         matched.add(regex)
-                return pri
+                        return pri
         return 0
 
     def get_bbfiles(self):


### PR DESCRIPTION
The fix is based on a patch submitted to BitBake developers list:
- https://patchwork.openembedded.org/patch/132413/

Unfortunately the patch hasn't been accepted yet.